### PR TITLE
ops: bump tips-cli (main.rs was not updated)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tips-cli"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 [dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use std::process::Command;
 
 #[derive(Parser, Debug)]
-#[command(version = "0.2.0", about = "A Rust version of tips CLI")]
+#[command(version = "0.2.2", about = "A Rust version of tips CLI")]
 struct Args {
     #[command(subcommand)]
     command: Option<Commands>,


### PR DESCRIPTION
I should consider to introduce https://github.com/callowayproject/bump-my-version.