### PR TITLE
misc: introduce bump-my-version

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,0 +1,20 @@
+[tool.bumpversion]
+current_version = "0.2.2"
+parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
+serialize = ["{major}.{minor}.{patch}"]
+search = "{current_version}"
+replace = "{new_version}"
+regex = false
+ignore_missing_version = false
+ignore_missing_files = false
+tag = false
+sign_tags = false
+tag_name = "v{new_version}"
+tag_message = "Bump version: {current_version} → {new_version}"
+allow_dirty = true
+commit = true
+message = "Bump version: {current_version} → {new_version}"
+commit_args = ""
+setup_hooks = []
+pre_commit_hooks = []
+post_commit_hooks = []

--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -18,3 +18,19 @@ commit_args = ""
 setup_hooks = []
 pre_commit_hooks = []
 post_commit_hooks = []
+
+[[tool.bumpversion.files]]
+filename = "Cargo.toml"
+search   = """
+[package]
+name = \"tips-cli\"
+version = \"{current_version}\""""
+replace  = """
+[package]
+name = \"tips-cli\"
+version = \"{new_version}\""""
+
+[[tool.bumpversion.files]]
+filename = "src/main.rs"
+search   = "#[command(version = \"{current_version}\", about"
+replace  = "#[command(version = \"{new_version}\", about"


### PR DESCRIPTION
Use [Bump My Version](https://callowayproject.github.io/bump-my-version/) to manage the version of tips-cli.

Note that bump-my-version is managed by `uvx`.